### PR TITLE
Simpler file list

### DIFF
--- a/Cask
+++ b/Cask
@@ -9,4 +9,4 @@
  (depends-on "coffee-mode")
  (depends-on "js2-mode"))
 
-(files "mocha-snippets.el" ("snippets" "snippets/*"))
+(files "mocha-snippets.el" "snippets")


### PR DESCRIPTION
Since cask uses the MELPA `package-build` library under the covers, I'm pretty sure this is equivalent.
