### PR TITLE
add snippets for "context" bdd alias

### DIFF
--- a/snippets/coffee-mode/mocha/context.snippet
+++ b/snippets/coffee-mode/mocha/context.snippet
@@ -1,0 +1,5 @@
+# -*- mode: snippet -*-
+# name: context block
+# key: cont
+# --
+context '${1: context}', -> $0

--- a/snippets/js-mode/mocha/context.snippet
+++ b/snippets/js-mode/mocha/context.snippet
@@ -1,0 +1,8 @@
+# -*- mode: snippet; require-final-newline: nil -*-
+# name: context block
+# key: cont
+# binding:
+# --
+context("${1: context}", function() {
+$0
+});


### PR DESCRIPTION
I like to use the [context alias](https://mochajs.org/#interfaces) for `describe` to improve test readability.  This PR adds coffee-mode and js-mode snippets for `context`.
