### PR TITLE
Allow custom string delimiters

### DIFF
--- a/features/mocha-snippets.feature
+++ b/features/mocha-snippets.feature
@@ -24,3 +24,18 @@ Feature: Using Mocha Snippets in JavaScript
     And I type "bef"
     And I press "TAB"
     Then I should see "beforeEach(function() {"
+
+Feature: Customizing snippet expansion
+  Some people use '' delimited strings, others use "". It's up to
+  them, but whatever they choose, we want to make sure that they have
+  the option to use the snippets, but apply their own style. This
+  means changing how strings are represented as well as how function
+  syntax is used.
+  
+  Scenario:
+    Given I am in buffer "string-delimiter.js"
+    And I turn on js-mode
+    And I customize the string delimiter to double quote
+    And I type "desc"
+    And I press "TAB"
+    Then I should see "describe("context", function() {"

--- a/features/step-definitions/mocha-yasnippets-steps.el
+++ b/features/step-definitions/mocha-yasnippets-steps.el
@@ -2,27 +2,7 @@
 ;; files in this directory whose names end with "-steps.el" will be
 ;; loaded automatically by Ecukes.
 
-(Given "^I have \"\\(.+\\)\"$"
-  (lambda (something)
-    ;; ...
-    ))
-
-(When "^I have \"\\(.+\\)\"$"
-  (lambda (something)
-    ;; ...
-    ))
-
-(Then "^I should have \"\\(.+\\)\"$"
-  (lambda (something)
-    ;; ...
-    ))
-
-(And "^I have \"\\(.+\\)\"$"
-  (lambda (something)
-    ;; ...
-    ))
-
-(But "^I should not have \"\\(.+\\)\"$"
-  (lambda (something)
-    ;; ...
-    ))
+(And "^I customize the string delimiter to double quote$"
+     (lambda ()
+       (make-local-variable 'mocha-snippets-string-delimiter)
+       (setq mocha-snippets-string-delimiter "\"")))

--- a/mocha-snippets.el
+++ b/mocha-snippets.el
@@ -63,5 +63,12 @@
 (eval-after-load "yasnippet"
   '(mocha-snippets-initialize))
 
+(defcustom mocha-snippets-string-delimiter "'"
+  "String delimiter will be used when expanding mocha snippets.
+Some people like to use single quotes, others double quotes.  This let's them
+choose."
+  :type 'string
+  :group 'mocha-snippets)
+
 (provide 'mocha-snippets)
 ;;; mocha-snippets.el ends here

--- a/snippets/coffee-mode/mocha/context.snippet
+++ b/snippets/coffee-mode/mocha/context.snippet
@@ -2,4 +2,4 @@
 # name: context block
 # key: cont
 # --
-context '${1: context}', -> $0
+context `mocha-snippets-string-delimiter`${1:context}`mocha-snippets-string-delimiter`, -> $0

--- a/snippets/coffee-mode/mocha/describe.snippet
+++ b/snippets/coffee-mode/mocha/describe.snippet
@@ -2,4 +2,4 @@
 # name: describe block
 # key: desc
 # --
-describe '${1: context}', -> $0
+describe `mocha-snippets-string-delimiter`${1: context}`mocha-snippets-string-delimiter`, -> $0

--- a/snippets/coffee-mode/mocha/it.snippet
+++ b/snippets/coffee-mode/mocha/it.snippet
@@ -2,4 +2,4 @@
 # name: it
 # key: it
 # --
-it '${1:is observed to have done something}', -> $0
+it `mocha-snippets-string-delimiter`${1:is observed to have done something}`mocha-snippets-string-delimiter`, -> $0

--- a/snippets/coffee-mode/mocha/it_done.snippet
+++ b/snippets/coffee-mode/mocha/it_done.snippet
@@ -2,4 +2,4 @@
 # name: it done
 # key: it.
 # --
-it '${1:is observed to have done something}', (done) -> $0
+it `mocha-snippets-string-delimiter`${1:is observed to have done something}`mocha-snippets-string-delimiter`, (done) -> $0

--- a/snippets/js-mode/mocha/context.snippet
+++ b/snippets/js-mode/mocha/context.snippet
@@ -1,8 +1,7 @@
 # -*- mode: snippet; require-final-newline: nil -*-
 # name: context block
 # key: cont
-# binding:
 # --
-context("${1: context}", function() {
+context(`mocha-snippets-string-delimiter`${1: context}`mocha-snippets-string-delimiter`, function() {
 $0
 });

--- a/snippets/js-mode/mocha/describe.snippet
+++ b/snippets/js-mode/mocha/describe.snippet
@@ -1,8 +1,7 @@
 # -*- mode: snippet; require-final-newline: nil -*-
 # name: describe
 # key: desc
-# binding:
 # --
-describe("${1: context}", function() {
+describe(`mocha-snippets-string-delimiter`${1:context}`mocha-snippets-string-delimiter`, function() {
 $0
 });

--- a/snippets/js-mode/mocha/it.snippet
+++ b/snippets/js-mode/mocha/it.snippet
@@ -2,6 +2,6 @@
 # name: it
 # key: it
 # --
-it("$1", function() {
+it(`mocha-snippets-string-delimiter`$1`mocha-snippets-string-delimiter`, function() {
   $0
 });


### PR DESCRIPTION
Some projects prefer `'` to delimite JavaScript strings, others prefer
`"`. The mocha code in a project should obviously follow suit, but right
now snippets are hard-coded to use `"`. This changes the default to `'`
since it seems to be gaining in popularity, but it also adds the custom
variable `mocha-snippets-string-delimiter` which will be used for all of
the strings in its templates.

To customize the string delimiter for a single project to be the
backtick for example, you could do so by putting the following pair in
your `.dir-locals.el` file.

```elisp
((js2-mode . ((mocha-snippets-string-delimiter . "`"))))
```