### PR TITLE
Allow customization of ES6 syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,58 @@ been given to `beforeEach` and `afterEach` respectively, since
 those are more commonly used (and if they aren't, then perhaps they
 shoud be)
 
+### Customization
+
+Mocha snippets have several configuration points to let your control
+how snippets are generated.
+
+#### mocha-snippets-string-delimiter
+
+By default, mocha snippets uses single quotes to delimit strings in
+its templates. However, you can set this variable to either `"` or
+`\`` to use a different delimiter:
+
+``` javascript
+//desc=>
+describe('something', function() {
+  //cursor here.
+});
+```
+
+configure the varibale
+
+``` emacs-lisp
+(setq mocha-snippets-string-delimiter "\"")
+```
+
+and it now becomes:
+``` javascript
+//desc=>
+describe("something", function() {
+  //cursor here.
+});
+```
+
+#### mocha-snippets-use-fat-arrows
+
+Out of the box, mocha will use "classic" function syntax for all of
+the functions it generates for you. However, if you like to use ES6
+fat arrow syntax, you can set this variable and your snippets will now
+all use it.
+
+``` emacs-lisp
+(setq mocha-snippets-use-fat-arrows t)
+```
+
+``` javascript
+//desc=>
+describe('something', ()=> {
+  //cursor here.
+});
+```
+
+
+
+
 [1]: https://mochajs.org
 [2]: https://mochajs.org/#asynchronous-code

--- a/features/mocha-snippets.feature
+++ b/features/mocha-snippets.feature
@@ -39,3 +39,19 @@ Feature: Customizing snippet expansion
     And I type "desc"
     And I press "TAB"
     Then I should see "describe("context", function() {"
+
+  Scenario:
+    Given I am in buffer "function-syntax.js"
+    And I turn on js-mode
+    And I customize the function syntax to =>
+    And I type "bef"
+    And I press "TAB"
+    Then I should see "beforeEach(()=> {"
+
+  Scenario:
+    Given I am in buffer "donezo.js"
+    And I turn on js-mode
+    And I customize the function syntax to =>
+    And I type "bef."
+    And I press "TAB"
+    Then I should see "beforeEach((done)=> {"

--- a/features/step-definitions/mocha-yasnippets-steps.el
+++ b/features/step-definitions/mocha-yasnippets-steps.el
@@ -6,3 +6,8 @@
      (lambda ()
        (make-local-variable 'mocha-snippets-string-delimiter)
        (setq mocha-snippets-string-delimiter "\"")))
+
+(And "^I customize the function syntax to =>$"
+     (lambda ()
+       (make-local-variable 'mocha-snippets-use-fat-arrows)
+       (setq mocha-snippets-use-fat-arrows t)))

--- a/mocha-snippets.el
+++ b/mocha-snippets.el
@@ -54,6 +54,7 @@
 
 ;;;###autoload
 (defun mocha-snippets-initialize ()
+  "Add mocha-snippets directories to YAS."
   (let ((snip-dir (expand-file-name "snippets" mocha-snippets-root)))
     (when (boundp 'yas-snippet-dirs)
       (add-to-list 'yas-snippet-dirs snip-dir t))
@@ -69,6 +70,28 @@ Some people like to use single quotes, others double quotes.  This let's them
 choose."
   :type 'string
   :group 'mocha-snippets)
+
+(defcustom mocha-snippets-use-fat-arrows nil
+  "Use ES6 ()=> syntax for function declarations if non-nil."
+  :type 'boolean
+  :group 'mocha-snippets
+  :require 'mocha-snippets)
+
+
+(defun mocha-snippets-function-declaration (&optional params)
+  "Function head appropriate for the desired syntax.
+The user can configure whether to use the ES6 function syntax or the 'classic'
+function syntax.  This will return the appropriate declaration depending on
+which is configured: either 'function()' or '()=>'.
+
+PARAMS, will be substituded as the parameter list for the function.
+E.g.
+
+  (mocha-snippets-initialize \"hello, world\") => function(hello, world)"
+  (let ((params (if (not params) "" params)))
+      (if mocha-snippets-use-fat-arrows
+          (format  "(%s)=>" params)
+        (format "function(%s)" params))))
 
 (provide 'mocha-snippets)
 ;;; mocha-snippets.el ends here

--- a/snippets/js-mode/mocha/after.snippet
+++ b/snippets/js-mode/mocha/after.snippet
@@ -2,6 +2,6 @@
 # name: after
 # key: after
 # --
-after(function() {
+after(`(mocha-snippets-function-declaration)` {
 $0
 });

--- a/snippets/js-mode/mocha/afterEach.snippet
+++ b/snippets/js-mode/mocha/afterEach.snippet
@@ -2,6 +2,6 @@
 # name: afterEach
 # key: aft
 # --
-afterEach(function() {
+afterEach(`(mocha-snippets-function-declaration)` {
 $0
 });

--- a/snippets/js-mode/mocha/afterEach_done.snippet
+++ b/snippets/js-mode/mocha/afterEach_done.snippet
@@ -2,6 +2,6 @@
 # name: afterEach done
 # key: aft.
 # --
-afterEach(function(done) {
+afterEach(`(mocha-snippets-function-declaration "done")` {
 $0
 });

--- a/snippets/js-mode/mocha/after_done.snippet
+++ b/snippets/js-mode/mocha/after_done.snippet
@@ -2,6 +2,6 @@
 # name: after done
 # key: after.
 # --
-after(function(done) {
+after(`(mocha-snippets-function-declaration "done")` {
 $0
 });

--- a/snippets/js-mode/mocha/before.snippet
+++ b/snippets/js-mode/mocha/before.snippet
@@ -2,6 +2,6 @@
 # name: before
 # key: before
 # --
-before(function() {
+before(`(mocha-snippets-function-declaration)` {
 $0
 });

--- a/snippets/js-mode/mocha/beforeEach.snippet
+++ b/snippets/js-mode/mocha/beforeEach.snippet
@@ -2,6 +2,6 @@
 # name: beforeEach
 # key: bef
 # --
-beforeEach(function() {
+beforeEach(`(mocha-snippets-function-declaration)` {
 $0
 });

--- a/snippets/js-mode/mocha/beforeEach_done.snippet
+++ b/snippets/js-mode/mocha/beforeEach_done.snippet
@@ -2,6 +2,6 @@
 # name: beforeEach done
 # key: bef.
 # --
-beforeEach(function(done) {
+beforeEach(`(mocha-snippets-function-declaration "done")` {
 $0
 });

--- a/snippets/js-mode/mocha/before_done.snippet
+++ b/snippets/js-mode/mocha/before_done.snippet
@@ -2,6 +2,6 @@
 # name: before done
 # key: before.
 # --
-before(function(done) {
+before(`(mocha-snippets-function-declaration "done")` {
 $0
 });

--- a/snippets/js-mode/mocha/context.snippet
+++ b/snippets/js-mode/mocha/context.snippet
@@ -2,6 +2,6 @@
 # name: context block
 # key: cont
 # --
-context(`mocha-snippets-string-delimiter`${1: context}`mocha-snippets-string-delimiter`, function() {
+context(`mocha-snippets-string-delimiter`${1: context}`mocha-snippets-string-delimiter`, `(mocha-snippets-function-declaration)` {
 $0
 });

--- a/snippets/js-mode/mocha/describe.snippet
+++ b/snippets/js-mode/mocha/describe.snippet
@@ -2,6 +2,6 @@
 # name: describe
 # key: desc
 # --
-describe(`mocha-snippets-string-delimiter`${1:context}`mocha-snippets-string-delimiter`, function() {
+describe(`mocha-snippets-string-delimiter`${1:context}`mocha-snippets-string-delimiter`, `(mocha-snippets-function-declaration)` {
 $0
 });

--- a/snippets/js-mode/mocha/it.snippet
+++ b/snippets/js-mode/mocha/it.snippet
@@ -2,6 +2,6 @@
 # name: it
 # key: it
 # --
-it(`mocha-snippets-string-delimiter`$1`mocha-snippets-string-delimiter`, function() {
+it(`mocha-snippets-string-delimiter`$1`mocha-snippets-string-delimiter`, `(mocha-snippets-function-declaration)` {
   $0
 });

--- a/snippets/js-mode/mocha/it_done.snippet
+++ b/snippets/js-mode/mocha/it_done.snippet
@@ -2,6 +2,6 @@
 # name: it done
 # key: it.
 # --
-it("$1", function(done) {
+it("$1", `(mocha-snippets-function-declaration "done")` {
   $0
 });


### PR DESCRIPTION
Some folks love those fat arrows. If you do, then your mocha snippets should play along. The default is still to use the classic function syntax, but if you set `mocha-snippets-use-fat-arrows` configuration option to `t`, then it will use fat arrows instead.