### PR TITLE
add option to add space after function keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,29 @@ describe('something', ()=> {
 });
 ```
 
+#### mocha-snippet-add-space-after-function-keyword
 
+Some linting tools requires you to add a space after `function`
+keyword. You have the option to customize it with
+
+``` emacs-lisp
+(setq mocha-snippets-add-space-after-function-keyword t)
+```
+
+``` javascript
+//desc=>
+describe('something', function () {
+  //cursor here.
+});
+```
+
+``` javascript
+//ES6
+//desc=>
+describe('something', () => {
+  //cursor here.
+})
+```
 
 
 [1]: https://mochajs.org

--- a/mocha-snippets.el
+++ b/mocha-snippets.el
@@ -77,6 +77,12 @@ choose."
   :group 'mocha-snippets
   :require 'mocha-snippets)
 
+(defcustom mocha-snippets-add-space-after-function-keyword nil
+  "Add space between function and ()
+or (in ES6) between () and => if non-nil."
+  :type 'boolean
+  :group 'mocha-snippets
+  :require 'mocha-snippets)
 
 (defun mocha-snippets-function-declaration (&optional params)
   "Function head appropriate for the desired syntax.
@@ -88,10 +94,11 @@ PARAMS, will be substituded as the parameter list for the function.
 E.g.
 
   (mocha-snippets-initialize \"hello, world\") => function(hello, world)"
-  (let ((params (if (not params) "" params)))
+  (let ((params (if (not params) "" params))
+        (space (if mocha-snippets-add-space-after-function-keyword " " "")))
       (if mocha-snippets-use-fat-arrows
-          (format  "(%s)=>" params)
-        (format "function(%s)" params))))
+          (format  "(%s)%s=>" params space)
+        (format "function%s(%s)" space params))))
 
 (provide 'mocha-snippets)
 ;;; mocha-snippets.el ends here


### PR DESCRIPTION
some linting tools like [standard](http://standardjs.com/rules.html) requires a space after `function` keyword like this: `function () {}`. This PR gives the user option to customize it.