### PR TITLE
Make fat arrows the default.

### DIFF
--- a/features/mocha-snippets.feature
+++ b/features/mocha-snippets.feature
@@ -9,7 +9,7 @@ Feature: Using Mocha Snippets in JavaScript
     When I turn on js-mode
     And I type "bef"
     And I press "TAB"
-    Then I should see "beforeEach(function() {"
+    Then I should see "beforeEach(() => {"
 
   Scenario: It loads CoffeScript snippets
     Given I am in buffer "some.coffee"
@@ -23,7 +23,7 @@ Feature: Using Mocha Snippets in JavaScript
     When I turn on js2-mode
     And I type "bef"
     And I press "TAB"
-    Then I should see "beforeEach(function() {"
+    Then I should see "beforeEach(() => {"
 
 Feature: Customizing snippet expansion
   Some people use '' delimited strings, others use "". It's up to
@@ -31,27 +31,27 @@ Feature: Customizing snippet expansion
   the option to use the snippets, but apply their own style. This
   means changing how strings are represented as well as how function
   syntax is used.
-  
+
   Scenario:
     Given I am in buffer "string-delimiter.js"
     And I turn on js-mode
     And I customize the string delimiter to double quote
     And I type "desc"
     And I press "TAB"
-    Then I should see "describe("context", function() {"
+    Then I should see "describe("context", () => {"
 
   Scenario:
     Given I am in buffer "function-syntax.js"
     And I turn on js-mode
-    And I customize the function syntax to =>
+    And I customize the function syntax to unbound function
     And I type "bef"
     And I press "TAB"
-    Then I should see "beforeEach(()=> {"
+    Then I should see "beforeEach(function() {"
 
   Scenario:
     Given I am in buffer "donezo.js"
     And I turn on js-mode
-    And I customize the function syntax to =>
+    And I customize the function syntax to unbound function
     And I type "bef."
     And I press "TAB"
-    Then I should see "beforeEach((done)=> {"
+    Then I should see "beforeEach(function(done) {"

--- a/features/step-definitions/mocha-yasnippets-steps.el
+++ b/features/step-definitions/mocha-yasnippets-steps.el
@@ -7,7 +7,7 @@
        (make-local-variable 'mocha-snippets-string-delimiter)
        (setq mocha-snippets-string-delimiter "\"")))
 
-(And "^I customize the function syntax to =>$"
+(And "^I customize the function syntax to unbound function$"
      (lambda ()
        (make-local-variable 'mocha-snippets-use-fat-arrows)
-       (setq mocha-snippets-use-fat-arrows t)))
+       (setq mocha-snippets-use-fat-arrows nil)))

--- a/mocha-snippets.el
+++ b/mocha-snippets.el
@@ -71,7 +71,7 @@ choose."
   :type 'string
   :group 'mocha-snippets)
 
-(defcustom mocha-snippets-use-fat-arrows nil
+(defcustom mocha-snippets-use-fat-arrows t
   "Use ES6 ()=> syntax for function declarations if non-nil."
   :type 'boolean
   :group 'mocha-snippets
@@ -97,7 +97,7 @@ E.g.
   (let ((params (if (not params) "" params))
         (space (if mocha-snippets-add-space-after-function-keyword " " "")))
       (if mocha-snippets-use-fat-arrows
-          (format  "(%s)%s=>" params space)
+          (format  "(%s) =>" params)
         (format "function%s(%s)" space params))))
 
 (provide 'mocha-snippets)


### PR DESCRIPTION
ES6 has been around for awhile and is coming to dominate the mochastyle.

This is a breaking change that makes bound functions the default.